### PR TITLE
Support for input in freestyle format

### DIFF
--- a/HISTORY.markdown
+++ b/HISTORY.markdown
@@ -7,6 +7,9 @@ Version 0.12 "Schoenhofen Brewery" (current development version):
     `string.replace` instead of `re.sub` so that backslash-escaping
     is not perfomed on the replacement string.  (Thanks to
     James Holderness for bug report and patch.)
+*   In "freestyle" format, lines beginning with `<= `, `<== `, or
+    `<=== ` can supply a section of test input text (Thanks to
+    James Holderness for feature suggestion and patch.)
 
 Version 0.11 "Dan Ryan Expressway" (current released version):
 

--- a/doc/Falderal_Literate_Test_Format.markdown
+++ b/doc/Falderal_Literate_Test_Format.markdown
@@ -6,8 +6,8 @@ This document describes the proposed Falderal Literate Test Format.
 Status
 ------
 
-This document is a *draft*.  It is nominally "version 0.11" because it
-describes something that version 0.11 of `py-falderal` mostly implements.
+This document is a *draft*.  It is nominally "version 0.12" because it
+describes something that version 0.12 of `py-falderal` mostly implements.
 We will deign to note which sections of this document the current released
 version of `py-falderal` implements, and which it does not.  However,
 this document is a work in progress, subject to change, and subject to get
@@ -89,10 +89,18 @@ introducers:
 *   `??> `: expected error text
 *   `???> `: expected error text
 
+In addition, the following introducers may be used to mark a section
+of test input text on the first of the final lines (but may not be
+used to end a block):
+
+*   `<= `: test input text
+*   `<== `: test input text
+*   `>=== `: test input text
+
 If a block is identified as a freestyle block, all lines preceding the
-final lines with one of these introducers, are interpreted as having
-no introducer at all (even if they begin with `| ` or some other sequence
-already mentioned) and are used as the test body block.
+first final line appearing with one of these introducers, are interpreted
+as having no introducer at all (even if they begin with `| ` or some other
+sequence already mentioned) and are used as the test body block.
 
 Lines without introducers are called _intervening text_.
 Lines of intervening text are classified as either blank or non-blank.  A
@@ -264,6 +272,17 @@ Valid examples in the "freestyle" format:
 
     thing to test
     ???> error to expect
+
+    thing to test
+    <=== input to give it
+    ===> output to expect
+
+    thing to test
+    <=== input to give it
+    ???> error to expect
+
+    <=== different input to give the immediately previously defined test body
+    ???> different error to expect
 
 Invalid examples:
 

--- a/doc/Falderal_Literate_Test_Format.markdown
+++ b/doc/Falderal_Literate_Test_Format.markdown
@@ -95,7 +95,7 @@ used to end a block):
 
 *   `<= `: test input text
 *   `<== `: test input text
-*   `>=== `: test input text
+*   `<=== `: test input text
 
 If a block is identified as a freestyle block, all lines preceding the
 first final line appearing with one of these introducers, are interpreted

--- a/doc/Falderal_Literate_Test_Format.markdown
+++ b/doc/Falderal_Literate_Test_Format.markdown
@@ -281,9 +281,6 @@ Valid examples in the "freestyle" format:
     <=== input to give it
     ???> error to expect
 
-    <=== different input to give the immediately previously defined test body
-    ???> different error to expect
-
 Invalid examples:
 
     | thing to test
@@ -293,7 +290,12 @@ Invalid examples:
     + input to give it
     = output to expect
 
-...test input must be preceded by a test body (if this is the first test.)
+...test input must be preceded by a test body, if this is the first test.
+
+    <=== input to give it
+    ???> output to expect
+
+...test input must be preceded by a test body always, in freestyle format.
 
     ? error to expect
 

--- a/src/falderal/objects.py
+++ b/src/falderal/objects.py
@@ -197,6 +197,9 @@ class Block(object):
     """
 
     FREESTYLE_MAP = {
+        u'<= ':   u'+ ',
+        u'<== ':  u'+ ',
+        u'<=== ': u'+ ',
         u'=> ':   u'= ',
         u'==> ':  u'= ',
         u'===> ': u'= ',

--- a/tests/test-freestyle-format.expected
+++ b/tests/test-freestyle-format.expected
@@ -42,5 +42,5 @@ Actual  : output:
 ? rreoww
 
 --------------------------------
-Total test runs: 10, failures: 3
+Total test runs: 13, failures: 3
 --------------------------------

--- a/tests/test-freestyle-format.expected
+++ b/tests/test-freestyle-format.expected
@@ -41,6 +41,22 @@ Actual  : output:
 | meow
 ? rreoww
 
+FAILED  : 
+
+The trick of re-using the previous test body with a different
+test input if the test body is omitted doesn't work with
+freestyle-format test input sections (i.e., this will fail.)
+
+Location: test-freestyle-format.markdown, line 111
+Function: Silly Interpreter
+Impl    : shell command "python silly-interpreter.py %(test-body-file)"
+Body    : 
+Expected: output:
+zang
+zing
+Actual  : output:
+
+
 --------------------------------
-Total test runs: 13, failures: 3
+Total test runs: 14, failures: 4
 --------------------------------

--- a/tests/test-freestyle-format.expected
+++ b/tests/test-freestyle-format.expected
@@ -31,12 +31,15 @@ Demonstrate error expectation (Intentional fail.)
 Location: test-freestyle-format.markdown, line 68
 Function: Cat
 Impl    : shell command "python cat.py"
-Body    : meow
+Body    : 
+| meow
+? rreoww
 Expected: error:
 bow
 wow
 Actual  : output:
-meow
+| meow
+? rreoww
 
 --------------------------------
 Total test runs: 10, failures: 3

--- a/tests/test-freestyle-format.markdown
+++ b/tests/test-freestyle-format.markdown
@@ -103,3 +103,12 @@ Freestyle-format tests can also contain input sections.
     <=== purr
     ===> purr
     ===> meow
+
+The trick of re-using the previous test body with a different
+test input if the test body is omitted doesn't work with
+freestyle-format test input sections (i.e., this will fail.)
+
+    <== zing
+    <== zang
+    ==> zang
+    ==> zing

--- a/tests/test-freestyle-format.markdown
+++ b/tests/test-freestyle-format.markdown
@@ -1,12 +1,12 @@
-Falderal Test: "new" format for tests
+Falderal Test: "freestyle" format for tests
 -------------------------------------
 
-This document tests the alternate format for tests introduced in
-the Falderal Literate Test Format version 0.11.  This format allows
-the test body to consist entirely of un-prefixed text, as long as
-it is written in a single indented block, and the final line(s) of
-the test begin with one of the prefixes `=> ` or `==> ` or `===> `
-or `?> ` or `??> `or `???> `.
+This document tests the alternate ("freestyle") format for tests
+introduced in the Falderal Literate Test Format version 0.11.  This
+format allows the test body to consist entirely of un-prefixed text,
+as long as it is written in a single indented block, and as long as
+the final line(s) of the test begin with one of the prefixes
+`=> ` or `==> ` or `===> ` or `?> ` or `??> `or `???> `.
 
     -> Functionality "Cat" is implemented by shell command "python cat.py"
 
@@ -38,17 +38,17 @@ as prefixes.
 
     | purr
     | prrr
-    | prreow
-    ==> | purr
-    ==> | prrr
-    ==> | prreow
+    = prreow
+    => | purr
+    => | prrr
+    => = prreow
 
     | purr
     + prrr
-    + prreow
+    ? prreow
     => | purr
     => + prrr
-    => + prreow
+    => ? prreow
 
     purr
     -> prrr
@@ -65,6 +65,7 @@ Demonstrate error expectation (Intentional fail.)
     meow
     ??> woof
 
-    meow
+    | meow
+    ? rreoww
     ???> bow
     ???> wow

--- a/tests/test-freestyle-format.markdown
+++ b/tests/test-freestyle-format.markdown
@@ -69,3 +69,37 @@ Demonstrate error expectation (Intentional fail.)
     ? rreoww
     ???> bow
     ???> wow
+
+Freestyle-format tests can also contain input sections.
+
+    -> Functionality "Silly Interpreter" is implemented by
+    -> shell command "python silly-interpreter.py %(test-body-file)"
+
+    -> Tests for functionality "Silly Interpreter"
+
+    read x
+    read y
+    print y
+    print x
+    <= meow
+    <= purr
+    => purr
+    => meow
+
+    read x
+    read y
+    print y
+    print x
+    <== meow
+    <== purr
+    ==> purr
+    ==> meow
+
+    read x
+    read y
+    print y
+    print x
+    <=== meow
+    <=== purr
+    ===> purr
+    ===> meow

--- a/tests/test-input-sections.expected
+++ b/tests/test-input-sections.expected
@@ -1,3 +1,3 @@
 --------------------------------
-Total test runs: 5, failures: 0
+Total test runs: 6, failures: 0
 --------------------------------

--- a/tests/test-input-sections.markdown
+++ b/tests/test-input-sections.markdown
@@ -38,3 +38,11 @@ Test tests that have test input sections.
     + purr
     = purr
     = meow
+
+If the input section appears first (i.e. there is no test body),
+the previous test body is re-used.
+
+    + zing
+    + zang
+    = zang
+    = zing


### PR DESCRIPTION
This applies the patch from #3 and adds tests and documentation.  @j4james you might want to take a look at it.

One thing the patch does not do, is support blocks that start with an input section.  The semantics for this, in the traditional format, is to re-use the previous tests' test body (and just run it again with different input.)  Implementing this with freestyle format probably means adding an extra test somewhere else in the code where it handles this case, but instead of looking for that place and doing that, I just left that combination as unsupported for now (it's not a huge burden, usually; you can just copy and paste test bodies multiple times in your document instead; and it can be always be added later.)